### PR TITLE
sirius: add  missing audio properties

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -1,5 +1,8 @@
 # Audio
-ro.vendor.audio.soundfx.type=mi
+ro.vendor.audio.soundfx.type=dirac
+vendor.audio.feature.compr_voip.enable=true
+vendor.audio.voice.receiver.status=off
+vendor.voice.path.for.pcm.voip=true
 
 # Display
 ro.surface_flinger.has_wide_color_display=true


### PR DESCRIPTION
Add audio properties that are not common with other sdm710 based
devices.

Signed-off-by: Ivan Vecera <ivecera@redhat.com>
Change-Id: I8f2fdfde1d622a13c37cab735303ef0f45465ec0